### PR TITLE
Alternatives pour le chargement d'un plugin via -buildplugin

### DIFF
--- a/go-1-8/main.go
+++ b/go-1-8/main.go
@@ -34,18 +34,18 @@ func registerPlugin(path string) (*Plugin, error) {
 		return nil, err
 	}
 
-	funcSymbol, err := p.Lookup("Greetings")
+	interfaceSymbol, err := p.Lookup("Greeter")
 	if err != nil {
 		return nil, err
 	}
 
-	greet := *funcSymbol.(*types.MyFunc)
+	greet := interfaceSymbol.(types.Greeter)
 
 	log.Printf("Plugin successfully installed\n")
 
 	plugin := &Plugin{
-		Path:      path,
-		Greetings: greet,
+		Path:    path,
+		Greeter: greet,
 	}
 
 	return plugin, nil

--- a/go-1-8/main.go
+++ b/go-1-8/main.go
@@ -39,7 +39,7 @@ func registerPlugin(path string) (*Plugin, error) {
 		return nil, err
 	}
 
-	greet := interfaceSymbol.(types.Greeter)
+	greet := *interfaceSymbol.(*types.Greeter)
 
 	log.Printf("Plugin successfully installed\n")
 

--- a/go-1-8/main.go
+++ b/go-1-8/main.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"os"
 	"plugin"
+
+	"github.com/golang-rennes/demo-plugins/go-1-8/types"
 )
 
 func main() {
@@ -37,7 +39,7 @@ func registerPlugin(path string) (*Plugin, error) {
 		return nil, err
 	}
 
-	greet := funcSymbol.(func(...string) string)
+	greet := *funcSymbol.(*types.MyFunc)
 
 	log.Printf("Plugin successfully installed\n")
 

--- a/go-1-8/reverse/reverse.go
+++ b/go-1-8/reverse/reverse.go
@@ -3,6 +3,8 @@ package main
 import (
 	"C"
 	"strings"
+
+	"github.com/golang-rennes/demo-plugins/go-1-8/types"
 )
 
 type reverseGreeter struct{}
@@ -19,4 +21,4 @@ func (g reverseGreeter) Greetings(args ...string) string {
 	return name
 }
 
-var Greeter = reverseGreeter{}
+var Greeter = types.Greeter(reverseGreeter{})

--- a/go-1-8/reverse/reverse.go
+++ b/go-1-8/reverse/reverse.go
@@ -3,6 +3,8 @@ package main
 import (
 	"C"
 	"strings"
+
+	"github.com/golang-rennes/demo-plugins/go-1-8/types"
 )
 
 func reverse(s string) (result string) {
@@ -12,7 +14,7 @@ func reverse(s string) (result string) {
 	return
 }
 
-func Greetings(args ...string) string {
+var Greetings types.MyFunc = func(args ...string) string {
 	name := reverse(strings.Join(args, "_"))
 	return name
 }

--- a/go-1-8/reverse/reverse.go
+++ b/go-1-8/reverse/reverse.go
@@ -3,9 +3,9 @@ package main
 import (
 	"C"
 	"strings"
-
-	"github.com/golang-rennes/demo-plugins/go-1-8/types"
 )
+
+type reverseGreeter struct{}
 
 func reverse(s string) (result string) {
 	for _, v := range s {
@@ -14,7 +14,9 @@ func reverse(s string) (result string) {
 	return
 }
 
-var Greetings types.MyFunc = func(args ...string) string {
+func (g reverseGreeter) Greetings(args ...string) string {
 	name := reverse(strings.Join(args, "_"))
 	return name
 }
+
+var Greeter = reverseGreeter{}

--- a/go-1-8/types.go
+++ b/go-1-8/types.go
@@ -1,6 +1,8 @@
 package main
 
+import "github.com/golang-rennes/demo-plugins/go-1-8/types"
+
 type Plugin struct {
-	Path      string
-	Greetings func(...string) string
+	Path string
+	types.Greeter
 }

--- a/go-1-8/types/func.go
+++ b/go-1-8/types/func.go
@@ -1,0 +1,3 @@
+package types
+
+type MyFunc func(...string) string

--- a/go-1-8/types/interface.go
+++ b/go-1-8/types/interface.go
@@ -1,0 +1,5 @@
+package types
+
+type Greeter interface {
+	Greetings(args ...string) string
+}

--- a/go-1-8/world/world.go
+++ b/go-1-8/world/world.go
@@ -3,8 +3,10 @@ package main
 import (
 	"C"
 	"strings"
+
+	"github.com/golang-rennes/demo-plugins/go-1-8/types"
 )
 
-func Greetings(args ...string) string {
+var Greetings types.MyFunc = func(args ...string) string {
 	return "World " + strings.Join(args, " ")
 }

--- a/go-1-8/world/world.go
+++ b/go-1-8/world/world.go
@@ -3,10 +3,12 @@ package main
 import (
 	"C"
 	"strings"
-
-	"github.com/golang-rennes/demo-plugins/go-1-8/types"
 )
 
-var Greetings types.MyFunc = func(args ...string) string {
+type worldGreeter struct{}
+
+func (g worldGreeter) Greetings(args ...string) string {
 	return "World " + strings.Join(args, " ")
 }
+
+var Greeter = worldGreeter{}

--- a/go-1-8/world/world.go
+++ b/go-1-8/world/world.go
@@ -3,6 +3,8 @@ package main
 import (
 	"C"
 	"strings"
+
+	"github.com/golang-rennes/demo-plugins/go-1-8/types"
 )
 
 type worldGreeter struct{}
@@ -11,4 +13,4 @@ func (g worldGreeter) Greetings(args ...string) string {
 	return "World " + strings.Join(args, " ")
 }
 
-var Greeter = worldGreeter{}
+var Greeter = types.Greeter(worldGreeter{})


### PR DESCRIPTION
@fsamin 

Merci pour la présentation d'hier, et désolé de ne pas avoir pu rester, on aurait pu discuter de cette PR ;-)

La partie 4 avec les plugins natifs en go 1.8 m'a bien plu et fait réfléchir (je savais pas que ça arrivait, c'est une bonne nouvelle !), voilà le résultat de mes réflexions et tests.

* Le symbole exporté semble être un pointeur vers le symbole, en fait. Je soupçonne que le pb que tu rencontrais en définissant le type de la fonction dans ton fichier `main.go` venait de là.

* Je n'ai pas réussi à le résoudre simplement, uniquement en passant par un type partagé entre le binaire et les plugins (`types.MyFunc`, cf commit [`7fac008`](https://github.com/golang-rennes/demo-plugins/pull/1/commits/7fac008b6284e31faed5bf585e5aafc05a827d7b)) et en explicitant le déréférencement du pointeur dans le cast.

* Je préfère (comme j'ai pu le faire en C++ par le passé) exporter un objet qui satisfait une interface commune, ça me semble plus clair, plus naturel et plus propre. C'est l'objet des 2 autres commits, qui chargent un objet de type `types.Greeter` (interface capable d'appeler une fonction `Greetings(...string) string`).
  Dans le dernier commit ([`a538af9`](https://github.com/golang-rennes/demo-plugins/pull/1/commits/a538af9c127b546436e84a04bd8126c265258bca)), je caste l'objet en l'interface avant l'export, ça permet de vérifier à la compilation qu'il sera bien compatible (mais ça oblige à nouveau à déréférencer l'interface une fois chargée).
  Je n'ai pas vraiment de préférence à priori entre ces 2 façons de faire… la première est plus sobre à écrire, la seconde plus sûre.